### PR TITLE
chore: read playwright[/test] versions dynamically in test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "typecheck": "tsc --noEmit",
     "format": "prettier --write '**/*.{html,js,ts,css,json,md}'",
     "check-format": "prettier --check '**/*.{html,js,ts,css,json,md}'",
-    "test": "docker run --rm --network=host --user $(id -u):$(id -g) -e HOME=/tmp -v $PWD:/app -w /app mcr.microsoft.com/playwright:v1.59.1 bash -c 'npm install --no-save --no-package-lock vite@8.0.3; npx vite --port 8000 & npx wait-on http://localhost:8000 && npx playwright test'",
-    "test:update-snapshots": "docker run --rm --network=host --user $(id -u):$(id -g) -e HOME=/tmp -v $PWD:/app -w /app mcr.microsoft.com/playwright:v1.59.1 bash -c 'npm install --no-save --no-package-lock vite@8.0.3; npx vite --port 8000 & npx wait-on http://localhost:8000 && npx playwright test --update-snapshots'"
+    "test": "docker run --rm --network=host --user $(id -u):$(id -g) -e HOME=/tmp -v $PWD:/app -w /app mcr.microsoft.com/playwright:v$(npm pkg get devDependencies.@playwright/test | tr -d '\"') bash -c 'npm install --no-save --no-package-lock vite@8.0.3; npx vite --port 8000 & npx wait-on http://localhost:8000 && npx playwright test'",
+    "test:update-snapshots": "docker run --rm --network=host --user $(id -u):$(id -g) -e HOME=/tmp -v $PWD:/app -w /app mcr.microsoft.com/playwright:v$(npm pkg get devDependencies.@playwright/test | tr -d '\"') bash -c 'npm install --no-save --no-package-lock vite@8.0.3; npx vite --port 8000 & npx wait-on http://localhost:8000 && npx playwright test --update-snapshots'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Without this, we have to update the test scripts every time these dependencies
are updated.
